### PR TITLE
Discard DenialConstraint in DiscardingResultReceiver

### DIFF
--- a/src/main/java/de/metanome/cli/DiscardingResultReceiver.java
+++ b/src/main/java/de/metanome/cli/DiscardingResultReceiver.java
@@ -52,6 +52,11 @@ public class DiscardingResultReceiver extends ResultReceiver {
     }
 
     @Override
+    public void receiveResult(DenialConstraint denialConstraint) throws CouldNotReceiveResultException, ColumnNameMismatchException {
+
+    }
+
+    @Override
     public void close() {
 
     }


### PR DESCRIPTION
I could not build against the latest version of Metanome due an extension of the `OmniscientResultReceiver` interface. Here is my suggested fix.

EDIT: I've just noticed this concerns not yet released functionality (Metanome master; seemingly `1.1-SNAPSHOT` is not deployed regularly?), so this PR is not too relevant I guess? Feel free to close.