### PR TITLE
Fix build error caused by new metadata types

### DIFF
--- a/src/main/java/de/metanome/cli/DiscardingResultReceiver.java
+++ b/src/main/java/de/metanome/cli/DiscardingResultReceiver.java
@@ -57,6 +57,16 @@ public class DiscardingResultReceiver extends ResultReceiver {
     }
 
     @Override
+    public void receiveResult(MatchingDependency matchingDependency) throws CouldNotReceiveResultException, ColumnNameMismatchException {
+
+    }
+
+    @Override
+    public void receiveResult(ConditionalFunctionalDependency conditionalFunctionalDependency) throws CouldNotReceiveResultException, ColumnNameMismatchException {
+
+    }
+
+    @Override
     public void close() {
 
     }


### PR DESCRIPTION
Metanome introduced new metadata types as mentioned in #8. Fully supporting them is not part of this PR and might not be necessary. This PR only prevents the build from failing. 